### PR TITLE
powo changed status for bad id

### DIFF
--- a/tests/testthat/test-powo.R
+++ b/tests/testthat/test-powo.R
@@ -31,7 +31,7 @@ test_that("taxon URL returns 404 for bad ID", {
   Sys.sleep(0.1)
   response <- httr::GET(url)
 
-  expect_equal(status_code(response), 404)
+  expect_equal(status_code(response), 400)
 })
 
 test_that("raises error for unimplemented keyword", {


### PR DESCRIPTION
Updated test after POWO changed the returned status code for submitting a bad taxon ID.